### PR TITLE
Use correct field name for test code

### DIFF
--- a/src/TestResult.hx
+++ b/src/TestResult.hx
@@ -28,7 +28,7 @@ class TestResult {
 			status: status.getName().toLowerCase(),
 			message: cleanedMessage,
 			output: truncateOutput(cleanedOutput),
-			testCode: testCode
+			test_code: testCode
 		};
 	}
 

--- a/test/fail/fail_has_stdout/expected_results.json
+++ b/test/fail/fail_has_stdout/expected_results.json
@@ -1,14 +1,14 @@
 {
-	"status": "fail",
-	"tests": [
-		{
-			"name": "identity function of 1",
-			"status": "fail",
-			"output": "hello",
-			"testCode": "FailHasStdout.identity(1).should.be(0);",
-			"message": "Expected 0, was 1"
-		}
-	],
-	"message": null,
-	"version": 2
+  "status": "fail",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "fail",
+      "output": "hello",
+      "test_code": "FailHasStdout.identity(1).should.be(0);",
+      "message": "Expected 0, was 1"
+    }
+  ],
+  "message": null,
+  "version": 2
 }

--- a/test/fail/fail_multiple/expected_results.json
+++ b/test/fail/fail_multiple/expected_results.json
@@ -1,35 +1,35 @@
 {
-	"status": "fail",
-	"tests": [
-		{
-			"name": "identity function of 1",
-			"status": "fail",
-			"output": null,
-			"testCode": "FailMultiple.funA(1).should.be(1);",
-			"message": "Expected 1, was -1"
-		},
-		{
-			"name": "identity function of 1",
-			"status": "fail",
-			"output": null,
-			"testCode": "FailMultiple.funA(1).should.be(1);",
-			"message": "Expected 2, was -2"
-		},
-		{
-			"name": "identity function of 1",
-			"status": "pass",
-			"output": null,
-			"testCode": "FailMultiple.funA(1).should.be(1);",
-			"message": null
-		},
-		{
-			"name": "identity function of 1",
-			"status": "fail",
-			"output": null,
-			"testCode": "FailMultiple.funA(1).should.be(1);",
-			"message": "Expected 2, was 4"
-		}
-	],
-	"message": null,
-	"version": 2
+  "status": "fail",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "fail",
+      "output": null,
+      "test_code": "FailMultiple.funA(1).should.be(1);",
+      "message": "Expected 1, was -1"
+    },
+    {
+      "name": "identity function of 1",
+      "status": "fail",
+      "output": null,
+      "test_code": "FailMultiple.funA(1).should.be(1);",
+      "message": "Expected 2, was -2"
+    },
+    {
+      "name": "identity function of 1",
+      "status": "pass",
+      "output": null,
+      "test_code": "FailMultiple.funA(1).should.be(1);",
+      "message": null
+    },
+    {
+      "name": "identity function of 1",
+      "status": "fail",
+      "output": null,
+      "test_code": "FailMultiple.funA(1).should.be(1);",
+      "message": "Expected 2, was 4"
+    }
+  ],
+  "message": null,
+  "version": 2
 }

--- a/test/fail/fail_partial/expected_results.json
+++ b/test/fail/fail_partial/expected_results.json
@@ -1,21 +1,21 @@
 {
-	"status": "fail",
-	"tests": [
-		{
-			"name": "identity function of 0",
-			"status": "fail",
-			"output": null,
-			"testCode": "FailPartial.identity(0).should.be(1);",
-			"message": "Expected 1, was 0"
-		},
-		{
-			"name": "identity function of 1",
-			"status": "pass",
-			"output": null,
-			"testCode": "FailPartial.identity(1).should.be(1);",
-			"message": null
-		}
-	],
-	"message": null,
-	"version": 2
+  "status": "fail",
+  "tests": [
+    {
+      "name": "identity function of 0",
+      "status": "fail",
+      "output": null,
+      "test_code": "FailPartial.identity(0).should.be(1);",
+      "message": "Expected 1, was 0"
+    },
+    {
+      "name": "identity function of 1",
+      "status": "pass",
+      "output": null,
+      "test_code": "FailPartial.identity(1).should.be(1);",
+      "message": null
+    }
+  ],
+  "message": null,
+  "version": 2
 }

--- a/test/fail/fail_single/expected_results.json
+++ b/test/fail/fail_single/expected_results.json
@@ -1,14 +1,14 @@
 {
-	"status": "fail",
-	"tests": [
-		{
-			"name": "identity function of 1",
-			"status": "fail",
-			"output": null,
-			"testCode": "FailSingle.identity(1).should.be(1);",
-			"message": "Expected 1, was null"
-		}
-	],
-	"message": null,
-	"version": 2
+  "status": "fail",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "fail",
+      "output": null,
+      "test_code": "FailSingle.identity(1).should.be(1);",
+      "message": "Expected 1, was null"
+    }
+  ],
+  "message": null,
+  "version": 2
 }

--- a/test/fail/runtime_exception_in_solution/expected_results.json
+++ b/test/fail/runtime_exception_in_solution/expected_results.json
@@ -1,14 +1,14 @@
 {
-	"status": "fail",
-	"tests": [
-		{
-			"name": "identity function of 1",
-			"status": "fail",
-			"output": null,
-			"testCode": "RuntimeExceptionInSolution.identity(1).should.be(1);",
-			"message": "runtime exception"
-		}
-	],
-	"message": null,
-	"version": 2
+  "status": "fail",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "fail",
+      "output": null,
+      "test_code": "RuntimeExceptionInSolution.identity(1).should.be(1);",
+      "message": "runtime exception"
+    }
+  ],
+  "message": null,
+  "version": 2
 }

--- a/test/pass/success_has_stdout/expected_results.json
+++ b/test/pass/success_has_stdout/expected_results.json
@@ -1,14 +1,14 @@
 {
-	"status": "pass",
-	"tests": [
-		{
-			"name": "identity function of 1",
-			"status": "pass",
-			"output": "hello",
-			"testCode": "SuccessHasStdout.identity(1).should.be(1);",
-			"message": null
-		}
-	],
-	"message": null,
-	"version": 2
+  "status": "pass",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "pass",
+      "output": "hello",
+      "test_code": "SuccessHasStdout.identity(1).should.be(1);",
+      "message": null
+    }
+  ],
+  "message": null,
+  "version": 2
 }

--- a/test/pass/success_has_stdout_truncated/expected_results.json
+++ b/test/pass/success_has_stdout_truncated/expected_results.json
@@ -1,14 +1,14 @@
 {
-	"status": "pass",
-	"tests": [
-		{
-			"name": "identity function of 1",
-			"status": "pass",
-			"output": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque lacinia non augue nec sodales. Duis a euismod nisi. Aenean auctor quam leo, sit amet mattis orci euismod et. Vivamus accumsan magna id scelerisque molestie. In tempor vel metus et pellentesque. Aliquam porttitor mattis lectus, mattis porta diam feugiat at. Ut imperdiet nibh a auctor convallis. Proin auctor augue cursus, bibendum lorem nec, varius tortor. Proin porttitor ligula risus, fermentum finibus eros porta ut. Proin ornare, j...\n[Output was truncated. Please limit to 500 chars]",
-			"testCode": "SuccessHasStdoutTruncated.identity(1).should.be(1);",
-			"message": null
-		}
-	],
-	"message": null,
-	"version": 2
+  "status": "pass",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "pass",
+      "output": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque lacinia non augue nec sodales. Duis a euismod nisi. Aenean auctor quam leo, sit amet mattis orci euismod et. Vivamus accumsan magna id scelerisque molestie. In tempor vel metus et pellentesque. Aliquam porttitor mattis lectus, mattis porta diam feugiat at. Ut imperdiet nibh a auctor convallis. Proin auctor augue cursus, bibendum lorem nec, varius tortor. Proin porttitor ligula risus, fermentum finibus eros porta ut. Proin ornare, j...\n[Output was truncated. Please limit to 500 chars]",
+      "test_code": "SuccessHasStdoutTruncated.identity(1).should.be(1);",
+      "message": null
+    }
+  ],
+  "message": null,
+  "version": 2
 }

--- a/test/pass/success_hello_world/expected_results.json
+++ b/test/pass/success_hello_world/expected_results.json
@@ -1,14 +1,14 @@
 {
-	"status": "pass",
-	"tests": [
-		{
-			"name": "Say Hi!",
-			"status": "pass",
-			"output": null,
-			"testCode": "SuccessHelloWorld.hello().should.be(\"Hello, World!\");",
-			"message": null
-		}
-	],
-	"message": null,
-	"version": 2
+  "status": "pass",
+  "tests": [
+    {
+      "name": "Say Hi!",
+      "status": "pass",
+      "output": null,
+      "test_code": "SuccessHelloWorld.hello().should.be(\"Hello, World!\");",
+      "message": null
+    }
+  ],
+  "message": null,
+  "version": 2
 }

--- a/test/pass/success_multiple/expected_results.json
+++ b/test/pass/success_multiple/expected_results.json
@@ -1,21 +1,21 @@
 {
-	"status": "pass",
-	"tests": [
-		{
-			"name": "identity function of 0",
-			"status": "pass",
-			"output": null,
-			"testCode": "SuccessMultiple.identity(0).should.be(0);",
-			"message": null
-		},
-		{
-			"name": "identity function of 1",
-			"status": "pass",
-			"output": null,
-			"testCode": "SuccessMultiple.identity(1).should.be(1);",
-			"message": null
-		}
-	],
-	"message": null,
-	"version": 2
+  "status": "pass",
+  "tests": [
+    {
+      "name": "identity function of 0",
+      "status": "pass",
+      "output": null,
+      "test_code": "SuccessMultiple.identity(0).should.be(0);",
+      "message": null
+    },
+    {
+      "name": "identity function of 1",
+      "status": "pass",
+      "output": null,
+      "test_code": "SuccessMultiple.identity(1).should.be(1);",
+      "message": null
+    }
+  ],
+  "message": null,
+  "version": 2
 }

--- a/test/pass/success_single/expected_results.json
+++ b/test/pass/success_single/expected_results.json
@@ -1,14 +1,14 @@
 {
-	"status": "pass",
-	"tests": [
-		{
-			"name": "identity function of 1",
-			"status": "pass",
-			"output": null,
-			"testCode": "SuccessSingle.identity(1).should.be(1);",
-			"message": null
-		}
-	],
-	"message": null,
-	"version": 2
+  "status": "pass",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "pass",
+      "output": null,
+      "test_code": "SuccessSingle.identity(1).should.be(1);",
+      "message": null
+    }
+  ],
+  "message": null,
+  "version": 2
 }


### PR DESCRIPTION
This commit changes the test code's field being output from `testCode`
to `test_code`.
See https://exercism.org/docs/building/tooling/test-runners/interface
for more information.
