### PR TITLE
Use xit for non-first test

### DIFF
--- a/test/fail/fail_multiple/test/Test.hx
+++ b/test/fail/fail_multiple/test/Test.hx
@@ -8,10 +8,10 @@ class Test extends buddy.SingleSuite {
 			it("identity function of 1", {
 				FailMultiple.funA(1).should.be(1);
 			});
-			it("identity function of 1", {
+			xit("identity function of 1", {
 				FailMultiple.funA(2).should.be(2);
 			});
-			it("identity function of 1", {
+			xit("identity function of 1", {
 				FailMultiple.funB(1).should.be(1);
 			});
 			it("identity function of 1", {

--- a/test/fail/fail_partial/test/Test.hx
+++ b/test/fail/fail_partial/test/Test.hx
@@ -8,7 +8,7 @@ class Test extends buddy.SingleSuite {
 			it("identity function of 0", {
 				FailPartial.identity(0).should.be(1);
 			});
-			it("identity function of 1", {
+			xit("identity function of 1", {
 				FailPartial.identity(1).should.be(1);
 			});
 		});


### PR DESCRIPTION
@BNAndras First step: making sure that the tests themselves use `xit` where applicable