### PR TITLE
Add datetime library

### DIFF
--- a/build.hxml
+++ b/build.hxml
@@ -2,6 +2,7 @@
 -cp src
 -neko bin/runner.n
 -lib buddy
+-lib datetime
 --resource src/Reporter.hx@Reporter
 --resource src/RunnerResult.hx@RunnerResult
 --resource src/TestResult.hx@TestResult


### PR DESCRIPTION
Fixes #23. The Docker file uses `haxelib install all` which grabs all libraries referenced in the .hxml files it finds (build.hxml and test.hxml). So I'm adding the datetime library here similar to how buddy is being added. That'll help with running the gigasecond exercise in particular