### PR TITLE
/opt/test-runner/test

### DIFF
--- a/bin/run-tests-in-docker.sh
+++ b/bin/run-tests-in-docker.sh
@@ -19,7 +19,7 @@ docker build --rm -t exercism/haxe-test-runner .
 docker run \
     --rm \
     --network none \
-    --mount type=bind,src="${PWD}/test",dst=/opt/test-runner/tests \
+    --mount type=bind,src="${PWD}/test",dst=/opt/test-runner/test \
     --mount type=tmpfs,dst=/tmp \
     --volume "${PWD}/bin/run-tests.sh:/opt/test-runner/bin/run-tests.sh" \
     --workdir /opt/test-runner \


### PR DESCRIPTION
`bin/run-tests-in-docker.sh` mounts the tests in
`/opt/test-runner/test`

This is where `bin/run-tests.sh` expects to find them.