### PR TITLE
rebaseline expected_results.json

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,14 @@
+name: shellcheck
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  shellcheck:
+    name: Run shellcheck on scripts
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM haxe:4.2-alpine
 
-RUN apk add --no-cache bash jq
+RUN apk add --no-cache bash
 
 COPY . /opt/test-runner
 WORKDIR /opt/test-runner

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -10,12 +10,7 @@ for test in test/*; do
         if [ -d "$testdir" ]; then
             bin/run.sh "$testname" "$testdir" "$output_dir"
 
-            # if ! diff "${output_dir}/results.json" "${output_dir}/expected_results.json"; then
-
-            diff <(jq --sort-keys . "${output_dir}/results.json") \
-                 <(jq --sort-keys . "${output_dir}/expected_results.json")
-
-            if (( $? != 0 )); then
+            if ! diff "${output_dir}/results.json" "${output_dir}/expected_results.json"; then
                 echo "❌ ${testdir} FAILED"
                 exit_code=1
             fi

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -9,10 +9,9 @@ fi
 slug="$1"
 solution_dir="${2%/}"
 output_dir="${3%/}"
-results_file="${output_dir}/results.json"
 
 echo "${slug}: testing..."
 
-neko bin/runner.n $slug $solution_dir/ $output_dir/
+neko bin/runner.n "${slug}" "${solution_dir}/" "${output_dir}/"
 
 echo "${slug}: done"

--- a/test/fail/fail_has_stdout/expected_results.json
+++ b/test/fail/fail_has_stdout/expected_results.json
@@ -1,14 +1,14 @@
 {
-  "status": "fail",
-  "tests": [
-    {
-      "name": "identity function of 1",
-      "status": "fail",
-      "output": "hello",
-      "test_code": "FailHasStdout.identity(1).should.be(0);",
-      "message": "Expected 0, was 1"
-    }
-  ],
-  "message": null,
-  "version": 2
+	"status": "fail",
+	"tests": [
+		{
+			"name": "identity function of 1",
+			"test_code": "FailHasStdout.identity(1).should.be(0);",
+			"status": "fail",
+			"output": "hello",
+			"message": "Expected 0, was 1"
+		}
+	],
+	"message": null,
+	"version": 2
 }

--- a/test/fail/fail_multiple/expected_results.json
+++ b/test/fail/fail_multiple/expected_results.json
@@ -1,35 +1,35 @@
 {
-  "status": "fail",
-  "tests": [
-    {
-      "name": "identity function of 1",
-      "status": "fail",
-      "output": null,
-      "test_code": "FailMultiple.funA(1).should.be(1);",
-      "message": "Expected 1, was -1"
-    },
-    {
-      "name": "identity function of 1",
-      "status": "fail",
-      "output": null,
-      "test_code": "FailMultiple.funA(1).should.be(1);",
-      "message": "Expected 2, was -2"
-    },
-    {
-      "name": "identity function of 1",
-      "status": "pass",
-      "output": null,
-      "test_code": "FailMultiple.funA(1).should.be(1);",
-      "message": null
-    },
-    {
-      "name": "identity function of 1",
-      "status": "fail",
-      "output": null,
-      "test_code": "FailMultiple.funA(1).should.be(1);",
-      "message": "Expected 2, was 4"
-    }
-  ],
-  "message": null,
-  "version": 2
+	"status": "fail",
+	"tests": [
+		{
+			"name": "identity function of 1",
+			"test_code": "FailMultiple.funA(1).should.be(1);",
+			"status": "fail",
+			"output": null,
+			"message": "Expected 1, was -1"
+		},
+		{
+			"name": "identity function of 1",
+			"test_code": "FailMultiple.funA(1).should.be(1);",
+			"status": "fail",
+			"output": null,
+			"message": "Expected 2, was -2"
+		},
+		{
+			"name": "identity function of 1",
+			"test_code": "FailMultiple.funA(1).should.be(1);",
+			"status": "pass",
+			"output": null,
+			"message": null
+		},
+		{
+			"name": "identity function of 1",
+			"test_code": "FailMultiple.funA(1).should.be(1);",
+			"status": "fail",
+			"output": null,
+			"message": "Expected 2, was 4"
+		}
+	],
+	"message": null,
+	"version": 2
 }

--- a/test/fail/fail_partial/expected_results.json
+++ b/test/fail/fail_partial/expected_results.json
@@ -1,21 +1,21 @@
 {
-  "status": "fail",
-  "tests": [
-    {
-      "name": "identity function of 0",
-      "status": "fail",
-      "output": null,
-      "test_code": "FailPartial.identity(0).should.be(1);",
-      "message": "Expected 1, was 0"
-    },
-    {
-      "name": "identity function of 1",
-      "status": "pass",
-      "output": null,
-      "test_code": "FailPartial.identity(1).should.be(1);",
-      "message": null
-    }
-  ],
-  "message": null,
-  "version": 2
+	"status": "fail",
+	"tests": [
+		{
+			"name": "identity function of 0",
+			"test_code": "FailPartial.identity(0).should.be(1);",
+			"status": "fail",
+			"output": null,
+			"message": "Expected 1, was 0"
+		},
+		{
+			"name": "identity function of 1",
+			"test_code": "FailPartial.identity(1).should.be(1);",
+			"status": "pass",
+			"output": null,
+			"message": null
+		}
+	],
+	"message": null,
+	"version": 2
 }

--- a/test/fail/fail_single/expected_results.json
+++ b/test/fail/fail_single/expected_results.json
@@ -1,14 +1,14 @@
 {
-  "status": "fail",
-  "tests": [
-    {
-      "name": "identity function of 1",
-      "status": "fail",
-      "output": null,
-      "test_code": "FailSingle.identity(1).should.be(1);",
-      "message": "Expected 1, was null"
-    }
-  ],
-  "message": null,
-  "version": 2
+	"status": "fail",
+	"tests": [
+		{
+			"name": "identity function of 1",
+			"test_code": "FailSingle.identity(1).should.be(1);",
+			"status": "fail",
+			"output": null,
+			"message": "Expected 1, was null"
+		}
+	],
+	"message": null,
+	"version": 2
 }

--- a/test/fail/runtime_exception_in_solution/expected_results.json
+++ b/test/fail/runtime_exception_in_solution/expected_results.json
@@ -1,14 +1,14 @@
 {
-  "status": "fail",
-  "tests": [
-    {
-      "name": "identity function of 1",
-      "status": "fail",
-      "output": null,
-      "test_code": "RuntimeExceptionInSolution.identity(1).should.be(1);",
-      "message": "runtime exception"
-    }
-  ],
-  "message": null,
-  "version": 2
+	"status": "fail",
+	"tests": [
+		{
+			"name": "identity function of 1",
+			"test_code": "RuntimeExceptionInSolution.identity(1).should.be(1);",
+			"status": "fail",
+			"output": null,
+			"message": "runtime exception"
+		}
+	],
+	"message": null,
+	"version": 2
 }

--- a/test/pass/success_has_stdout/expected_results.json
+++ b/test/pass/success_has_stdout/expected_results.json
@@ -1,14 +1,14 @@
 {
-  "status": "pass",
-  "tests": [
-    {
-      "name": "identity function of 1",
-      "status": "pass",
-      "output": "hello",
-      "test_code": "SuccessHasStdout.identity(1).should.be(1);",
-      "message": null
-    }
-  ],
-  "message": null,
-  "version": 2
+	"status": "pass",
+	"tests": [
+		{
+			"name": "identity function of 1",
+			"test_code": "SuccessHasStdout.identity(1).should.be(1);",
+			"status": "pass",
+			"output": "hello",
+			"message": null
+		}
+	],
+	"message": null,
+	"version": 2
 }

--- a/test/pass/success_has_stdout_truncated/expected_results.json
+++ b/test/pass/success_has_stdout_truncated/expected_results.json
@@ -1,14 +1,14 @@
 {
-  "status": "pass",
-  "tests": [
-    {
-      "name": "identity function of 1",
-      "status": "pass",
-      "output": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque lacinia non augue nec sodales. Duis a euismod nisi. Aenean auctor quam leo, sit amet mattis orci euismod et. Vivamus accumsan magna id scelerisque molestie. In tempor vel metus et pellentesque. Aliquam porttitor mattis lectus, mattis porta diam feugiat at. Ut imperdiet nibh a auctor convallis. Proin auctor augue cursus, bibendum lorem nec, varius tortor. Proin porttitor ligula risus, fermentum finibus eros porta ut. Proin ornare, j...\n[Output was truncated. Please limit to 500 chars]",
-      "test_code": "SuccessHasStdoutTruncated.identity(1).should.be(1);",
-      "message": null
-    }
-  ],
-  "message": null,
-  "version": 2
+	"status": "pass",
+	"tests": [
+		{
+			"name": "identity function of 1",
+			"test_code": "SuccessHasStdoutTruncated.identity(1).should.be(1);",
+			"status": "pass",
+			"output": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque lacinia non augue nec sodales. Duis a euismod nisi. Aenean auctor quam leo, sit amet mattis orci euismod et. Vivamus accumsan magna id scelerisque molestie. In tempor vel metus et pellentesque. Aliquam porttitor mattis lectus, mattis porta diam feugiat at. Ut imperdiet nibh a auctor convallis. Proin auctor augue cursus, bibendum lorem nec, varius tortor. Proin porttitor ligula risus, fermentum finibus eros porta ut. Proin ornare, j...\n[Output was truncated. Please limit to 500 chars]",
+			"message": null
+		}
+	],
+	"message": null,
+	"version": 2
 }

--- a/test/pass/success_hello_world/expected_results.json
+++ b/test/pass/success_hello_world/expected_results.json
@@ -1,14 +1,14 @@
 {
-  "status": "pass",
-  "tests": [
-    {
-      "name": "Say Hi!",
-      "status": "pass",
-      "output": null,
-      "test_code": "SuccessHelloWorld.hello().should.be(\"Hello, World!\");",
-      "message": null
-    }
-  ],
-  "message": null,
-  "version": 2
+	"status": "pass",
+	"tests": [
+		{
+			"name": "Say Hi!",
+			"test_code": "SuccessHelloWorld.hello().should.be(\"Hello, World!\");",
+			"status": "pass",
+			"output": null,
+			"message": null
+		}
+	],
+	"message": null,
+	"version": 2
 }

--- a/test/pass/success_multiple/expected_results.json
+++ b/test/pass/success_multiple/expected_results.json
@@ -1,21 +1,21 @@
 {
-  "status": "pass",
-  "tests": [
-    {
-      "name": "identity function of 0",
-      "status": "pass",
-      "output": null,
-      "test_code": "SuccessMultiple.identity(0).should.be(0);",
-      "message": null
-    },
-    {
-      "name": "identity function of 1",
-      "status": "pass",
-      "output": null,
-      "test_code": "SuccessMultiple.identity(1).should.be(1);",
-      "message": null
-    }
-  ],
-  "message": null,
-  "version": 2
+	"status": "pass",
+	"tests": [
+		{
+			"name": "identity function of 0",
+			"test_code": "SuccessMultiple.identity(0).should.be(0);",
+			"status": "pass",
+			"output": null,
+			"message": null
+		},
+		{
+			"name": "identity function of 1",
+			"test_code": "SuccessMultiple.identity(1).should.be(1);",
+			"status": "pass",
+			"output": null,
+			"message": null
+		}
+	],
+	"message": null,
+	"version": 2
 }

--- a/test/pass/success_single/expected_results.json
+++ b/test/pass/success_single/expected_results.json
@@ -1,14 +1,14 @@
 {
-  "status": "pass",
-  "tests": [
-    {
-      "name": "identity function of 1",
-      "status": "pass",
-      "output": null,
-      "test_code": "SuccessSingle.identity(1).should.be(1);",
-      "message": null
-    }
-  ],
-  "message": null,
-  "version": 2
+	"status": "pass",
+	"tests": [
+		{
+			"name": "identity function of 1",
+			"test_code": "SuccessSingle.identity(1).should.be(1);",
+			"status": "pass",
+			"output": null,
+			"message": null
+		}
+	],
+	"message": null,
+	"version": 2
 }


### PR DESCRIPTION
The sorting and whitespace of results.json differs now from 2022.

By updating expectations, we avoid the need for jq.

Add shellcheck github workflow